### PR TITLE
chore: fix artifact upload name

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: builds
+          name: artifacts
           retention-days: 1
           path: |
             artifacts/*SUMS*


### PR DESCRIPTION
bors r+